### PR TITLE
add current user endoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development do
 end
 
 group :development, :test do
+  gem 'pry-byebug'
   gem 'faker'
   gem 'rspec'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,10 @@ GEM
     bcrypt (3.1.11)
     boolean (1.0.1)
     builder (3.2.2)
+    byebug (9.0.6)
     cerulean (0.0.7)
       boolean
+    coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.0.2)
@@ -94,6 +96,13 @@ GEM
       pkg-config (~> 1.1.7)
     pg (0.18.4)
     pkg-config (1.1.7)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     rack (2.0.1)
     rack-cors (0.4.0)
     rack-test (0.6.3)
@@ -154,6 +163,7 @@ GEM
     shoulda-context (1.2.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    slop (3.6.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -187,6 +197,7 @@ DEPENDENCIES
   listen (~> 3.0)
   marky_markov
   pg (~> 0.18.4)
+  pry-byebug
   rack-cors (~> 0.4.0)
   rails (~> 5.0.0)
   rspec

--- a/app/controllers/v1/sessions_controller.rb
+++ b/app/controllers/v1/sessions_controller.rb
@@ -1,0 +1,9 @@
+class V1::SessionsController < ApplicationController
+  get :info do
+    presenter V1::UserPresenter
+    request do
+      present current_user, type: :detail
+    end
+  end
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :v1 do
     resources :recipes
+    get 'session/info', to: 'sessions#info'
     resources :users do
       collection do
         post :authenticate


### PR DESCRIPTION
Adds an endpoint to retrieve the current user.

I went back and forth on whether or not to safeguard this endpoint in some way. The `current_user` method wastes no time in going directly to the database, and leaving a call like that in a public place is how a DDOS attack gets a hold of your database.

However, I soon realized that the recipes list is public anyway, and if you were concerned about that risk at all, it wouldn't be. So I think this is okay.